### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Lightweight jQuery plugin to the EU cookie laws
     ```
     3. When using CDN
     ```html
-    <script src="//cdn.jsdelivr.net/jquery.cookiefy/1.0/jquery.cookiefy.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/jquery.cookiefy@1.0/dist/jquery.cookiefy.min.js"></script>
     ```
     4. When using downloaded files
     ```html


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/jquery.cookiefy.

Feel free to ping me if you have any questions regarding this change.